### PR TITLE
package.json: make DEBUG and webpack --mode flag work on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "geo_three",
   "version": "1.0.0",
   "scripts": {
-    "dev": "DEBUG=1 webpack serve --mode='development'",
-    "build": "DEBUG=0 webpack --mode='production'"
+    "dev": "set DEBUG=1 && webpack serve --mode=development",
+    "build": "set DEBUG=0 && webpack --mode=production"
   },
   "devDependencies": {
     "@babel/core": "^7.20.2",


### PR DESCRIPTION
changed npm run tasks in package.json to work on windows

`DEBUG=x` needed to be replaced with `set DEBUG=x &&` for windows to recognize the flag,
 
 `--mode='development'` needed to be replaced with `--mode=development` for webpack not to error on windows.
 
 ps: please make sure this works on macos, it's fine on linux and windows.